### PR TITLE
Include Databricks JDBC in build, add Export & Load functionality

### DIFF
--- a/IO/pom.xml
+++ b/IO/pom.xml
@@ -82,6 +82,7 @@
         <mssql.version>8.2.2.jre8</mssql.version>
         <db2.version>11.5.4.0</db2.version>
         <mariadb.version>2.6.2</mariadb.version>
+        <databricks.version>2.6.34</databricks.version>
     </properties>
 
     <dependencies>
@@ -131,6 +132,11 @@
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
             <version>${mariadb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.databricks</groupId>
+            <artifactId>databricks-jdbc</artifactId>
+            <version>${databricks.version}</version>
         </dependency>
         <!-- JDBC Connection Pooling -->
         <dependency>

--- a/IO/src/main/java/org/ohnlp/backbone/io/databricks/DatabricksExtract.java
+++ b/IO/src/main/java/org/ohnlp/backbone/io/databricks/DatabricksExtract.java
@@ -1,0 +1,230 @@
+package org.ohnlp.backbone.io.databricks;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CollectionCoder;
+import org.apache.beam.sdk.coders.RowCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.jdbc.JdbcIO;
+import org.apache.beam.sdk.io.jdbc.SchemaUtilProxy;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.*;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.ohnlp.backbone.api.annotations.ComponentDescription;
+import org.ohnlp.backbone.api.annotations.ConfigurationProperty;
+import org.ohnlp.backbone.api.components.ExtractToOne;
+import org.ohnlp.backbone.api.exceptions.ComponentInitializationException;
+import org.ohnlp.backbone.io.Repartition;
+
+import java.beans.PropertyVetoException;
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Performs data extraction using a JDBC connector
+ * This class uses {@link JdbcIO} included with Apache Beam to execute parallelized retrieval queries
+ * using offsets for pagination.
+ */
+@ComponentDescription(
+        name = "Read Records from JDBC-compatible data source",
+        desc = "Reads Records from a JDBC-compatible data source using a SQL query. Any queries should ideally " +
+                "include an indexed identifier column that can be used to rapidly paginate/partition results for " +
+                "parallelized processing"
+)
+public class DatabricksExtract extends ExtractToOne {
+    @ConfigurationProperty(
+            path = "url",
+            desc = "The JDBC URL to connect to"
+    )
+    private String url;
+    @ConfigurationProperty(
+            path = "driver",
+            desc = "The JDBC driver to use for the connection"
+    )
+    private String driver;
+    @ConfigurationProperty(
+            path = "user",
+            desc = "Database User"
+    )
+    private String user;
+    @ConfigurationProperty(
+            path = "password",
+            desc = "Database Password"
+    )
+    private String password;
+    @ConfigurationProperty(
+            path = "query",
+            desc = "Database Query to Execute"
+    )
+    private String query;
+    @ConfigurationProperty(
+            path = "batch_size",
+            desc = "Approximate number of documents per batch/partition. Lower this if running into memory issues.",
+            required = false
+    )
+    private int batchSize = 1000;
+    @ConfigurationProperty(
+            path = "identifier_col",
+            desc = "An ID column returned as part of the query that can be used to identify and partition records, " +
+                    "multiple columns can be entered in column-delimited order",
+            required = false
+    )
+    private String identifierCol = null;
+
+    @ConfigurationProperty(
+            path = "idle_timeout",
+            desc = "Amount of time in milliseconds to keep idle connections open. 0 for no limit",
+            required = false
+    )
+    private int idleTimeout = 0;
+
+    private JdbcIO.DataSourceConfiguration datasourceConfig;
+    private ComboPooledDataSource initializationDS;
+    private String viewName;
+    private Schema schema;
+    private String keyValueQuery;
+    private Schema keyValueSchema;
+
+    /**
+     * Initializes a Beam JdbcIO Provider
+     *
+     * <p>
+     * Expected configuration structure:
+     * <pre>
+     *     {
+     *         "url": "jdbc_url_to_database",
+     *         "driver": "jdbc.driver.class",
+     *         "user": "dbUsername",
+     *         "password": "dbPassword",
+     *         "query": "query_to_execute_for_extract_task",
+     *         "batch_size": integer_batch_size_per_partition_default_1000_if_blank,
+     *         "identifier_col": "column_with_identifier_values"
+     *     }
+     * </pre>
+     * <p>
+     * By default, batch_size and identifier_col are optional but are highly recommended as the defaults may
+     * not be optimal for performance
+     *
+     * @throws ComponentInitializationException if an error occurs during initialization or if configuraiton contains
+     *                                          unexpected values
+     */
+    public void init() throws ComponentInitializationException {
+        try {
+            this.initializationDS = new ComboPooledDataSource();
+            initializationDS.setAcquireRetryAttempts(1);
+            initializationDS.setDriverClass(driver);
+            initializationDS.setJdbcUrl(url);
+            initializationDS.setUser(user);
+            initializationDS.setPassword(password);
+            initializationDS.setMaxIdleTime(this.idleTimeout);
+            ComboPooledDataSource ds = new ComboPooledDataSource();
+            ds.setDriverClass(driver);
+            ds.setJdbcUrl(url);
+            ds.setUser(user);
+            ds.setPassword(password);
+            ds.setMaxIdleTime(this.idleTimeout);
+            this.datasourceConfig = JdbcIO.DataSourceConfiguration
+                    .create(ds);
+            // We will first preflight with a query that counts the number of records so that we can get number
+            // of batches
+            String runId = UUID.randomUUID().toString().replaceAll("-", "_");
+            this.viewName = "backbone_jdbcextract_" + runId;
+            if (this.identifierCol != null) {
+                this.keyValueQuery = "SELECT DISTINCT " + identifierCol + " FROM (" + query + ") " + viewName;
+                this.keyValueSchema = getIdentifierColumnsSchema();
+            }
+        } catch (Throwable t) {
+            throw new ComponentInitializationException(t);
+        }
+    }
+
+    @Override
+    public List<String> getOutputTags() {
+        return Collections.singletonList("JDBC Results");
+    }
+
+    @Override
+    public Schema calculateOutputSchema() {
+        Schema schema;
+        try (Connection conn = initializationDS.getConnection();
+             PreparedStatement ps = conn.prepareStatement(this.query, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY)) {
+            schema = SchemaUtilProxy.toBeamSchema(driver, ps.getMetaData());
+        } catch (SQLException throwables) {
+            throw new RuntimeException(throwables);
+        }
+        this.schema = schema;
+        return this.schema;
+    }
+
+    @Override
+    public PCollection<Row> begin(PBegin input) {
+        return input.apply() // Note that the code below will not work for the Databricks jdbc driver and must be modified
+//                     "Read from JDBC",
+//                     JdbcIO.<Row>read()
+//                     .withDataSourceConfiguration(datasourceConfig)
+//                     .withQuery("SELECT * FROM (" + this.query + ") " + this.viewName)
+//                     .withRowMapper(this.driver.equals("org.sqlite.JDBC") ?
+//                             new SchemaUtilProxy.SQLiteBeamRowMapperProxy(schema) :
+//                             new SchemaUtilProxy.BeamRowMapperProxy(schema))
+//                     .withCoder(RowCoder.of(schema))
+//                     .withOutputParallelization(false)
+//             ).apply("JDBC Break Fusion", Repartition.of()).setRowSchema(schema);
+    }
+
+    private Schema getIdentifierColumnsSchema() throws ComponentInitializationException {
+        String metaQuery = "SELECT " + this.identifierCol + " FROM (" + this.query + ") " + this.viewName;
+        try (Connection conn = this.initializationDS.getConnection()) {
+            ResultSetMetaData queryMeta = conn.prepareStatement(metaQuery).getMetaData();
+            if (queryMeta == null) {
+                throw new IllegalArgumentException("ResultSetMetadata is Null");
+            }
+            return SchemaUtilProxy.toBeamSchema(this.driver, queryMeta);
+        } catch (Throwable t) {
+            throw new ComponentInitializationException(new RuntimeException("Failed to pull identifier metadata for query " + metaQuery, t));
+        }
+    }
+
+    private String[] findPaginationOrderingColumns(String query) throws ComponentInitializationException {
+        try (Connection conn = this.initializationDS.getConnection()) {
+            ResultSetMetaData queryMeta = conn.prepareStatement(query).getMetaData();
+            Map<String, Integer> colNameToIndex = new HashMap<>();
+            for (int i = 0; i < queryMeta.getColumnCount(); i++) {
+                // Assume we are using a case-sensitive impl:
+                // config mismatches can be addressed via config change for identifierCol but same is not true if
+                // impl is case-sensitive and we try to use a case-normalized column name via automatic selection
+                colNameToIndex.put(queryMeta.getColumnLabel(i + 1), i + 1);
+            }
+            if (this.identifierCol != null) {
+                // User-supplied identifier column exists, make sure it actually exists in query results
+                String toCheck = this.identifierCol;
+                if (this.identifierCol.startsWith("\"") && this.identifierCol.endsWith("\"")) {
+                    toCheck = toCheck.substring(1, toCheck.length() - 1);
+                }
+                if (!colNameToIndex.containsKey(toCheck)) {
+                    throw new ComponentInitializationException(
+                            new IllegalArgumentException("The supplied identifier_col " + this.identifierCol + " " +
+                                    "does not exist in the returned query results. Available columns: " +
+                                    Arrays.toString(colNameToIndex.keySet().toArray(new String[0]))));
+                }
+                return new String[]{this.identifierCol};
+            } else {
+                // User did not supply an identifier column, so instead we will concatenate by column index so that
+                // ordering is done for all columns...
+                // Ideally we would want to instead look for a pk/unique constraint and order on that instead of on
+                // everything
+                List<String> colNames = new ArrayList<>();
+                for (int i = 0; i < queryMeta.getColumnCount(); i++) {
+                    colNames.add(queryMeta.getColumnLabel(i + 1));
+                }
+                return colNames.toArray(new String[0]);
+            }
+        } catch (SQLException t) {
+            throw new ComponentInitializationException(t);
+        }
+
+    }
+}

--- a/IO/src/main/java/org/ohnlp/backbone/io/databricks/DatabricksLoad.java
+++ b/IO/src/main/java/org/ohnlp/backbone/io/databricks/DatabricksLoad.java
@@ -1,0 +1,275 @@
+package org.ohnlp.backbone.io.databricks;
+
+import com.mchange.v2.c3p0.ComboPooledDataSource;
+import org.apache.beam.sdk.io.jdbc.JdbcIO;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.Row;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+import org.joda.time.ReadableDateTime;
+import org.ohnlp.backbone.api.annotations.ComponentDescription;
+import org.ohnlp.backbone.api.annotations.ConfigurationProperty;
+import org.ohnlp.backbone.api.annotations.InputColumnProperty;
+import org.ohnlp.backbone.api.components.LoadFromOne;
+import org.ohnlp.backbone.api.config.InputColumn;
+import org.ohnlp.backbone.api.exceptions.ComponentInitializationException;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Performs data load using a JDBC connector
+ * This class is essentially a configuration wrapper around the beam provided {@link JdbcIO} transform with additional
+ * support added for user-customizeable PreparedStatement usage
+ *
+ * <p>
+ * Expected configuration structure:
+ * <pre>
+ *     {
+ *         "url": "jdbc_url_to_database",
+ *         "driver": "jdbc.driver.class",
+ *         "user": "dbUsername",
+ *         "password": "dbPassword",
+ *         "query": "query_to_execute_for_load in preparedstatemnt format. Substitute ? for variables (1-indexed)",
+ *         "paramMappings": [
+ *              "this_column_name_will_be_mapped_to_the_first_?",
+ *              "this_column_name_will_be_mapped_to_the_second_?",
+ *              ...
+ *              etc.
+ *         ]
+ *     }
+ * </pre>
+ */
+@ComponentDescription(
+        name = "Write Records into JDBC-Compatible Data Source",
+        desc = "Writes records into a JDBC-compatible data source using a SQL query. The insert statements should " +
+                "follow Java PreparedStatement format (e.g. use ? for parameterized variables). The columns in " +
+                "the paramMappings configuration argument will be used to substitute values into the respective ? " +
+                "in the insert query in sequential order."
+)
+public class DatabricksLoad extends LoadFromOne {
+    @ConfigurationProperty(
+            path = "url",
+            desc = "The JDBC URL to connect to"
+    )
+    private String url;
+    @ConfigurationProperty(
+            path = "driver",
+            desc = "The JDBC driver to use for the connection"
+    )
+    private String driver;
+    @ConfigurationProperty(
+            path = "user",
+            desc = "Database User"
+    )
+    private String user;
+    @ConfigurationProperty(
+            path = "password",
+            desc = "Database Password"
+    )
+    private String password;
+    @ConfigurationProperty(
+            path = "query",
+            desc = "Database Query to use as inserts. Use ? to indicate column value arguments. " +
+                    "E.g., INSERT INTO tablename (column1, column2, column3) VALUES (?, ?, ?)"
+    )
+    private String query;
+    @ConfigurationProperty(
+            path = "paramMappings",
+            desc = "List of columns to use as values to insert. Should follow same order as the ?s used in the insert query"
+    )
+    @InputColumnProperty
+    private List<InputColumn> columnMappings;
+    @ConfigurationProperty(
+            path = "idleTimeout",
+            desc = "Amount of time in milliseconds to keep idle connections open. 0 for no limit",
+            required = false
+    )
+    private int idleTimeout = 0;
+    private JdbcIO.Write<Row> runnableInstance;
+
+    public void init() throws ComponentInitializationException {
+        try {
+            List<RowToPSMappingFunction> mappingOps = new LinkedList<>();
+            int i = 1;
+            for (InputColumn column : columnMappings) {
+                mappingOps.add(new RowToPSMappingFunction(i++, column.getSourceColumnName()));
+            }
+            ComboPooledDataSource ds = new ComboPooledDataSource();
+            ds.setDriverClass(driver);
+            ds.setJdbcUrl(url);
+            ds.setUser(user);
+            ds.setPassword(password);
+            ds.setMaxIdleTime(idleTimeout);
+            JdbcIO.DataSourceConfiguration datasourceConfig = JdbcIO.DataSourceConfiguration.create(ds);
+            this.runnableInstance = JdbcIO.<Row>write()
+                    .withDataSourceConfiguration(datasourceConfig)
+                    .withStatement(query)
+                    .withPreparedStatementSetter((JdbcIO.PreparedStatementSetter<Row>) (element, preparedStatement) -> {
+                        for (RowToPSMappingFunction func : mappingOps) {
+                            func.map(element, preparedStatement);
+                        }
+                    });
+        } catch (Throwable t) {
+            throw new ComponentInitializationException(t);
+        }
+    }
+
+    public PDone expand(PCollection<Row> input) {
+        return runnableInstance.expand(input);
+    }
+
+    // Handles execution of row to preparedstatement type mappings
+    private static class RowToPSMappingFunction implements Serializable {
+        private final String fieldName;
+        private final int idx;
+        private transient RowMappingFunction execute;
+
+        public RowToPSMappingFunction(int index, String fieldName) {
+            this.idx = index;
+            this.fieldName = fieldName;
+        }
+
+        public void map(Row row, PreparedStatement ps) throws SQLException {
+            // Do type resolution only once
+            if (this.execute == null) {
+                Schema.TypeName type = row.getSchema().getField(fieldName).getType().getTypeName();
+                if (type.isLogicalType()) {
+                    type = row.getSchema().getField(fieldName).getType().getLogicalType().getBaseType().getTypeName();
+                }
+                switch (type) {
+                    case BYTE:
+                        this.execute = (data, statement) -> {
+                            @Nullable @UnknownKeyFor @Initialized Byte val = data.getByte(this.fieldName);
+                            if (val != null) {
+                                statement.setByte(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.TINYINT);
+                            }
+                        };
+                        break;
+                    case INT16:
+                        this.execute = (data, statement) -> {
+                            Short val = data.getInt16(this.fieldName);
+                            if (val != null) {
+                                statement.setShort(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.SMALLINT);
+                            }
+                        };
+                        break;
+                    case INT32:
+                        this.execute = (data, statement) -> {
+                            Integer val = data.getInt32(this.fieldName);
+                            if (val != null) {
+                                statement.setInt(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.INTEGER);
+                            }
+                        };
+                        break;
+                    case INT64:
+                        this.execute = (data, statement) -> {
+                            Long val = data.getInt64(this.fieldName);
+                            if (val != null) {
+                                statement.setLong(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.BIGINT);
+                            }
+                        };
+                        break;
+                    case DECIMAL:
+                        this.execute = (data, statement) -> {
+                            BigDecimal val = data.getDecimal(this.fieldName);
+                            if (val != null) {
+                                statement.setBigDecimal(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.DECIMAL);
+                            }
+                        };
+                        break;
+                    case FLOAT:
+                        this.execute = (data, statement) -> {
+                            Float val = data.getFloat(this.fieldName);
+                            if (val != null) {
+                                statement.setFloat(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.FLOAT);
+                            }
+                        };
+                        break;
+                    case DOUBLE:
+                        this.execute = (data, statement) -> {
+                            Double val = data.getDouble(this.fieldName);
+                            if (val != null) {
+                                statement.setDouble(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.DOUBLE);
+                            }
+                        };
+                        break;
+                    case STRING:
+                        this.execute = (data, statement) -> {
+                            String val = data.getString(this.fieldName);
+                            if (val != null) {
+                                statement.setString(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.VARCHAR);
+                            }
+                        };
+                        break;
+                    case DATETIME:
+                        this.execute = (data, statement) -> {
+                            ReadableDateTime val = data.getDateTime(this.fieldName);
+                            if (val != null) {
+                                statement.setTimestamp(this.idx, new Timestamp(val.getMillis()));
+                            } else {
+                                statement.setNull(this.idx, Types.TIMESTAMP);
+                            }
+                        };
+                        break;
+                    case BOOLEAN:
+                        this.execute = (data, statement) -> {
+                            Boolean val = data.getBoolean(this.fieldName);
+                            if (val != null) {
+                                statement.setBoolean(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.BOOLEAN);
+                            }
+                        };
+                        break;
+                    case BYTES:
+                        this.execute = (data, statement) -> {
+                            byte[] val = data.getBytes(this.fieldName);
+                            if (val != null) {
+                                statement.setBytes(this.idx, val);
+                            } else {
+                                statement.setNull(this.idx, Types.VARBINARY);
+                            }
+                        };
+                        break;
+                    default:
+                        // TODO revisit the other options available
+                        throw new UnsupportedOperationException(type.name() + " is not currently a supported type for JDBC encoding");
+                }
+            }
+            this.execute.run(row, ps);
+        }
+    }
+
+    /**
+     * Interface definition for a row mapping function
+     */
+    private interface RowMappingFunction {
+        void run(Row row, PreparedStatement ps) throws SQLException;
+    }
+}


### PR DESCRIPTION
This PR aims to add Databricks as a possible JDBC option for the OHNLP pipeline.

Note that simply adding the JDBC driver into the IO build and referencing it in the config connection parameters is not sufficient to execute the process against a Databricks source, and the pipeline fails (submitted as a job to an integrated flink cluster) with the following error:

> `Exception in chained task 'FlatMap (FlatMap at Step-Read from OHDSI OMOP CDM NOTE Table via JDBC/JDBC Break Fusion/ParDo(Anonymous)2/ParMultiDo(Anonymous).output)'`
>
> `java.sql.SQLFeatureNotSupportedException: [Databricks][JDBC](10220) Driver does not support this optional feature.`

I've begun to add Databricks-specific code analogous to that for BigQuery, but I see that for the moment there are no Databricks-specific [beam classes](https://beam.apache.org/releases/javadoc/2.3.0/allclasses-noframe.html), and I wanted to see if @qqndrew might have any suggestions on how to proceed before diving too deeply into it. 

Also worth mentioning that the popularity of Databricks seems to be growing in the OMOP community, so a database-oriented work around would likely have impact beyond our specific site. 